### PR TITLE
12_install_via_pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /*/__pycache__
 /examples/temp.py 
+/voidsafe.egg-info
+/dist

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@
 
 ## Installation
 
-&nbsp;&nbsp;&nbsp;&nbsp; **voidsafe** will be added to **PyPi** soon...
+&nbsp;&nbsp;&nbsp;&nbsp; **VoidSafe** is on [**_PyPi_**](https://pypi.org/project/voidsafe/). You can install its latest version via `pip install` as follows:
+
+```console
+pip install voidsafe
+```
 
 ## Examples
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md


### PR DESCRIPTION
doc(*): Install via PyPi

- Added `twine-generated` directories to `.gitignore`;
- Added instructions on how to install the package;
- Added metadata about the project's description on `setup.cfg`.

#12: Install via PyPi
- Gustavo Cardoso Ribeiro